### PR TITLE
Optional override redirect to customer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/src/redirect-sca-sdk.js
+++ b/src/redirect-sca-sdk.js
@@ -33,7 +33,7 @@ function initState(baseUrl) {
     return helper.initState(baseUrl).then(state => {
         redirectSca.state = state;
         redirectSca.baseUrl = baseUrl;
-        return Promise.resolve(redirectSca.state);
+        return redirectSca.state;
     });
 }
 


### PR DESCRIPTION
- Allow to override the default functionality for the continue to customer redirect.
- Only clear storage keys that were set by the script, don't remove unrelated ones.
- Small refactorings.